### PR TITLE
Add a linter name

### DIFF
--- a/lib/linter-rails-best-practices.coffee
+++ b/lib/linter-rails-best-practices.coffee
@@ -48,6 +48,7 @@ module.exports =
 
   provideLinter: ->
     provider =
+      name: 'rails_best_practices'
       grammarScopes: [
         'source.ruby',
         'source.ruby.rails',


### PR DESCRIPTION
Add `rails_best_practices` as a provider name so this can be identified in the results when multiple providers return results for a file.